### PR TITLE
cron in uwsgi, host affinity

### DIFF
--- a/templates/geonode-generic/0/rancher-compose.yml
+++ b/templates/geonode-generic/0/rancher-compose.yml
@@ -70,14 +70,24 @@ catalog:
 services:
     db:
         scale: 1
+        labels:
+            io.rancher.scheduler.affinity:host_label: ${HOST_AFFINITY}
     django:
         retain_ip: true
         scale: 1
+        labels:
+            io.rancher.scheduler.affinity:host_label: ${HOST_AFFINITY}
     geoserver:
         scale: 1
+        labels:
+            io.rancher.scheduler.affinity:host_label: ${HOST_AFFINITY}
     geonode:
         scale: 1
+        labels:
+            io.rancher.scheduler.affinity:host_label: ${HOST_AFFINITY}
     data-dir-conf:
         labels:
-            io.rancher.container.start_once: true
+            io.rancher.container.start_once: true        
+            io.rancher.scheduler.affinity:host_label: ${HOST_AFFINITY}
         scale: 1
+

--- a/templates/geonode-generic/0/rancher-compose.yml
+++ b/templates/geonode-generic/0/rancher-compose.yml
@@ -2,7 +2,7 @@
 version: '2'
 catalog:
     name: "GeoNode generic"
-    version: "v1.0"
+    version: "v1.1"
     description: "Generic GeoNode deployment"
     uuid: geonode-generic-0
     minimum_rancher_version: 'v1.6'
@@ -54,6 +54,16 @@ catalog:
                 receive notifications. Entries
                 should be separated with coma.
           required: false
+          type: string
+          default:
+
+        - variable: "HOST_AFFINITY"
+          label: "Label of host to deploy on"
+          description: |
+                To keep containers running on specific
+                hosts, provide label attached to host
+                to deploy on.
+          required: true
           type: string
           default:
 

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -9,3 +9,4 @@ processes = 4
 plugins = python
 threads = 2
 home = /usr/local/
+cron = -1 -1 -1 -1 -1 /usr/local/bin/python /usr/src/app/manage.py collect_metrics


### PR DESCRIPTION
cron entry in uwsgi (so we won't rely directly on rancher infra/labels) for monitoring collector: https://github.com/geosolutions-it/geonode-generic/issues/4

host affinity in rancher (but transparent to plain docker-compose): #13 