### PR TITLE
Improvements to GeoNode Rancher catalog

### DIFF
--- a/templates/geonode-generic/0/docker-compose.yml
+++ b/templates/geonode-generic/0/docker-compose.yml
@@ -160,7 +160,7 @@ volumes:
 #    name: ${COMPOSE_PROJECT_NAME}-dbdata
   dbbackups:
      driver: ${BACKUPS_VOLUME_DRIVER}
-     external: ${BACKUPS_VOLUME_EXTERNAL}
+     external: {{ .Values.BACKUPS_VOLUME_EXTERNAL }}
 #    name: ${COMPOSE_PROJECT_NAME}-dbbackups
   statics:
 #    name: ${COMPOSE_PROJECT_NAME}-statics

--- a/templates/geonode-generic/0/docker-compose.yml
+++ b/templates/geonode-generic/0/docker-compose.yml
@@ -159,6 +159,7 @@ volumes:
   dbdata:
 #    name: ${COMPOSE_PROJECT_NAME}-dbdata
   dbbackups:
+     driver: ${BACKUPS_VOLUME_DRIVER}
 #    name: ${COMPOSE_PROJECT_NAME}-dbbackups
   statics:
 #    name: ${COMPOSE_PROJECT_NAME}-statics

--- a/templates/geonode-generic/0/docker-compose.yml
+++ b/templates/geonode-generic/0/docker-compose.yml
@@ -160,6 +160,7 @@ volumes:
 #    name: ${COMPOSE_PROJECT_NAME}-dbdata
   dbbackups:
      driver: ${BACKUPS_VOLUME_DRIVER}
+     external: ${BACKUPS_VOLUME_EXTERNAL}
 #    name: ${COMPOSE_PROJECT_NAME}-dbbackups
   statics:
 #    name: ${COMPOSE_PROJECT_NAME}-statics

--- a/templates/geonode-generic/0/docker-compose.yml
+++ b/templates/geonode-generic/0/docker-compose.yml
@@ -112,7 +112,7 @@ services:
       - django
       - geoserver
     ports:
-      - "${EXPOSED_HTTP_PORT}:80"
+      - "${NGINX_PORT_MAPPING}"
     volumes:
       - statics:/mnt/volumes/statics
 

--- a/templates/geonode-generic/0/rancher-compose.yml
+++ b/templates/geonode-generic/0/rancher-compose.yml
@@ -76,6 +76,15 @@ catalog:
           type: string
           default:
 
+        - variable: "BACKUPS_VOLUME_DRIVER"
+          label: "Backups Volume driver to use"
+          description: |
+              Volume driver to use for the Volume attached
+              to the abckups container (local, rancher-nfs, ...)
+          required: true
+          type: string
+          default: local
+
 services:
     db:
         scale: 1

--- a/templates/geonode-generic/0/rancher-compose.yml
+++ b/templates/geonode-generic/0/rancher-compose.yml
@@ -8,16 +8,16 @@ catalog:
     minimum_rancher_version: 'v1.6'
 
     questions:
-        - variable: "EXPOSED_HTTP_PORT"
-          label: "External ngxin port"
+        - variable: "NGINX_PORT_MAPPING"
+          label: "Port mapping for Nginx container"
           description: |
-                Port number on which nginx from this deployment will
-                be visible on the host. If you have multiple stacks or nginx
-                or load balancer running on host, you should set distinct
-                port here.
-          default: 80
-          required: false
-          type: "int"
+              Port mapping for Nginx container. For instance "80:80"
+              will map Nginx port 80 to port 80 of the host machine.
+              Set to "80" to assign a random port
+
+          default: "80:80"
+          required: true
+          type: "string"
         - variable: "ALLOWED_HOSTS"
           label: "List of allowed host header values"
           description: |

--- a/templates/geonode-generic/0/rancher-compose.yml
+++ b/templates/geonode-generic/0/rancher-compose.yml
@@ -16,7 +16,7 @@ catalog:
                 or load balancer running on host, you should set distinct
                 port here.
           default: 80
-          required: true
+          required: false
           type: "int"
         - variable: "ALLOWED_HOSTS"
           label: "List of allowed host header values"

--- a/templates/geonode-generic/0/rancher-compose.yml
+++ b/templates/geonode-generic/0/rancher-compose.yml
@@ -85,6 +85,14 @@ catalog:
           type: string
           default: local
 
+        - variable: "BACKUPS_VOLUME_EXTERNAL"
+          label: "Use pre-existing volume to store Backups"
+          description: |
+              Set to true to use a pre-existing Volume for backups,
+              set to false to create a named volume local to the stack.
+          required: true
+          type: boolean
+          default: false
 services:
     db:
         scale: 1


### PR DESCRIPTION
- Allow user to assign random port to Nginx container (avoid port clashing when running more than one instance on the same host)
- Allow use of "external" (pre-existing created) Docker Volumes for backup container. Used to create [environment scoped Volumes](https://rancher.com/docs/rancher/v1.2/en/rancher-services/storage-service/) on NFS for instance