### PR TITLE
re-create a docker-compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,133 @@
+version: '2'
+services:
+
+  db:
+    image: geosolutionsit/postgis-docker:9.6
+    restart: unless-stopped
+    container_name: db4${COMPOSE_PROJECT_NAME}
+    stdin_open: true
+    # tty: true
+    labels:
+      org.geonode.component: db
+      org.geonode.instance.name: geonode
+    volumes:
+      - dbdata:/var/lib/postgresql/data
+      - dbbackups:/pg_backups
+    environment:
+      GEONODE_DATABASE: geonode
+      GEONODE_DATABASE_PASSWORD: geonode
+      GEONODE_GEODATABASE: geonode_data
+      GEONODE_GEODATABASE_PASSWORD: geonode_data
+
+  django:
+    restart: unless-stopped
+    image: geosolutionsit/geonode-generic:1.0
+    container_name: django4${COMPOSE_PROJECT_NAME}
+    stdin_open: true
+    # tty: true
+    labels:
+      org.geonode.component: django
+      org.geonode.instance.name: geonode
+    depends_on:
+      - db
+    command: uwsgi --ini /usr/src/app/uwsgi.ini
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - statics:/mnt/volumes/statics
+    environment:
+       GEONODE_INSTANCE_NAME: geonode
+       GEONODE_LB_HOST_IP:
+       GEONODE_LB_PORT:
+       DATABASE_URL: postgres://postgres:postgres@db:5432/postgres
+       DEFAULT_BACKEND_DATASTORE: datastore
+       GEONODE_DATABASE: geonode
+       GEONODE_DATABASE_PASSWORD: geonode
+       GEONODE_GEODATABASE: geonode_data
+       GEONODE_GEODATABASE_PASSWORD: geonode_data
+       # BROKER_URL: amqp://guest:guest@rabbitmq:5672/
+       DJANGO_SETTINGS_MODULE: geonode_generic.settings
+       ALLOWED_HOSTS: []
+       DOCKER_ENV: production
+       UWSGI_CMD: uwsgi --ini /usr/src/app/uwsgi.ini
+       IS_CELERY: 'false'
+       C_FORCE_ROOT: 1
+       SITEURL: http://localhost/
+       # replaced with defaults in settings
+       GEOSERVER_PUBLIC_LOCATION: http://localhost/geoserver/
+       GEOSERVER_LOCATION: http://geoserver:8080/geoserver/
+       STATIC_ROOT: /mnt/volumes/statics/static/
+       MEDIA_ROOT: /mnt/volumes/statics/uploaded/
+       GEOIP_PATH: /mnt/volumes/statics/geoip.db
+       ALLOWED_HOSTS: "['*']"
+       ADMIN_EMAILS: ''
+       # mind that following lines are rancher-specific
+       #RANCHER_STACK: {{ .Stack.Name }}
+       #RANCHER_ENV: {{ .Environment.Name }}
+       GEOSERVER_ADMIN_PASSWORD: admin
+       # See https://github.com/geosolutions-it/geonode-generic/issues/28
+       # to see why we force API version to 1.24
+       DOCKER_API_VERSION: "1.24"
+
+  geoserver:
+    image: geosolutionsit/geoserver-docker:2.12.x
+    restart: unless-stopped
+    container_name: geoserver4${COMPOSE_PROJECT_NAME}
+    stdin_open: true
+    # tty: true
+    labels:
+        org.geonode.component: geoserver
+        org.geonode.instance.name: geonode
+    depends_on:
+      - db
+      - data-dir-conf
+    volumes:
+      - geoserver-data-dir:/geoserver_data/data
+    environment:
+      GEOSERVER_ADMIN_PASSWORD: admin
+      DOCKERHOST:
+      DOCKER_HOST_IP:
+      GEONODE_HOST_IP:
+      NGINX_BASE_URL: http://localhost/
+
+  geonode:
+    image: geosolutionsit/nginx-geonode:latest
+    restart: unless-stopped
+    container_name: nginx4${COMPOSE_PROJECT_NAME}
+    stdin_open: true
+    # tty: true
+    labels:
+        org.geonode.component: nginx
+        org.geonode.instance.name: geonode
+    depends_on:
+      - django
+      - geoserver
+    ports:
+      - 80:80
+    volumes:
+      - statics:/mnt/volumes/statics
+
+
+  data-dir-conf:
+    image: geosolutionsit/geoserver_data:2.12.x
+    restart: on-failure
+    container_name: gsconf4${COMPOSE_PROJECT_NAME}
+    labels:
+        org.geonode.component: conf
+        org.geonode.instance.name: geonode
+    command: /bin/true
+    # command: tail -f /dev/null
+    volumes:
+      - geoserver-data-dir:/geoserver_data/data
+
+
+volumes:
+  geoserver-data-dir:
+#    name: ${COMPOSE_PROJECT_NAME}-gsdatadir
+  dbdata:
+#    name: ${COMPOSE_PROJECT_NAME}-dbdata
+  dbbackups:
+#     driver: ${BACKUPS_VOLUME_DRIVER}
+#     external: {{ .Values.BACKUPS_VOLUME_EXTERNAL }}
+#    name: ${COMPOSE_PROJECT_NAME}-dbbackups
+  statics:
+#    name: ${COMPOSE_PROJECT_NAME}-statics


### PR DESCRIPTION
starting from the templates/geonode-generic/1/docker-compose.yml

Needed for development environment

Note: kept using geoserver 2.12 due to issues with 2.13 (i.e. default style for uploaded layers is of type raster, even though the layer is vector)