### PR TITLE
Fix for #42 and #24 - incorrect database being used.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,33 +1,70 @@
-Geonode_Generic
-========================
+# Geonode Generic
 
-GeoNode "materialized" project for vanilla GeoNode deployments.
+GeoNode "materialized" project for vanilla GeoNode deployments - this is
+[Kartoza's](http://kartoza.com) fork from the great work by 
+[Geosolutions-it](https://github.com/geosolutions-it/geonode-generic).
 
-Setup with Rancher 1.6
-----------------
+## Backups:
+
+
+Backups are made automatically each night.
+
+Backups will be made in ``/mnt/volumes/backups``. Backups are made using the
+[Geosolutions backup docker project](https://github.com/geosolutions-it/geonode-backup-docker). See
+restoring backups section below.
+
+## Restoring backups:
+
+There is a restore container for restoring backups. This is based on [the
+Geosolutions restore docker project](https://github.com/geosolutions-it/geonode-restore-docker).
+
+See the backups section above for details of how the backups work,
+
+
+## Setup with Rancher 1.6
 
 Currently this repository supports setup through Rancher 1.6.
-The catalog template is publicly available at https://store.docker.com/community/images/geosolutionsit/geonode-generic.
-You can load the template from Rancher UI or Rancher CLI and set the questions / variables defined in the Rancher compose file.
+The catalog template is publicly available via the (Kartoza rancher catalogue)[]
+
+You can load the template from Rancher UI or Rancher CLI and set the questions
+/ variables defined in the Rancher compose file.
 
 A standalone docker-compose will be reintroduced later.
 
 
-Configuration
-+++++++++++++
+## Configuration
 
-Since this application uses geonode, base source of settings is ``geonode.settings`` module. It provides defaults for many items, which are used by geonode. This application has own settings module, ``geonode_generic.settings``, which includes ``geonode.settings``. It customizes few elements:
- * static/media files locations - they will be collected and stored along with this application files by default. This is useful during development.
- * Adds ``geonode_generic`` to installed applications, updates templates, staticfiles dirs, sets urlconf to ``geonode_generic.urls``. 
+**Note these original notes from GeoSolutions need review**
 
-Whether you deploy development or production environment, you should create additional settings file. Convention is to make ``geonode_generic.local_settings`` module. It is recommended to use ``geonode_generic/local_settings.py``.. That file contains small subset of settings for edition. It should:
+Since this application uses geonode, base source of settings is
+``geonode.settings`` module. It provides defaults for many items, which are
+used by geonode. This application has own settings module,
+``geonode_generic.settings``, which includes ``geonode.settings``. It
+customizes few elements: * static/media files locations - they will be
+collected and stored along with this application files by default. This is
+useful during development.  * Adds ``geonode_generic`` to installed
+applications, updates templates, staticfiles dirs, sets urlconf to
+``geonode_generic.urls``. 
+
+Whether you deploy development or production environment, you should create
+additional settings file. Convention is to make
+``geonode_generic.local_settings`` module. It is recommended to use
+``geonode_generic/local_settings.py``.. That file contains small subset of
+settings for edition. It should:
  * not be versioned along with application (because changes you make for your private deployment may become public),
  * have customized at least``DATABASES``, ``SECRET_KEY`` and ``SITEURL``. 
 
-You can add more settings there, note however, some settings (notably ``DEBUG_STATIC``, ``EMAIL_ENABLE``, ``*_ROOT``, and few others) can be used by other settings, or as condition values, which change other settings. For example, ``EMAIL_ENABLE`` defined in ``geonode.settings`` enables whole email handling block, so if you disable it in your ``local_settings``, derived settings will be preserved. You should carefully check if additional settings you change don't trigger other settings.
+You can add more settings there, note however, some settings (notably
+``DEBUG_STATIC``, ``EMAIL_ENABLE``, ``*_ROOT``, and few others) can be used by
+other settings, or as condition values, which change other settings. For
+example, ``EMAIL_ENABLE`` defined in ``geonode.settings`` enables whole email
+handling block, so if you disable it in your ``local_settings``, derived
+settings will be preserved. You should carefully check if additional settings
+you change don't trigger other settings.
 
-To ilustrate whole concept of chanied settings:
-::
+To ilustrate the whole concept of chained settings:
+
+```
     +------------------------+-------------+-------------------------------+-------------+----------------------------------+
     |  GeoNode configuration |             |   Your application default    |             |  (optionally) Your deployment(s) |
     |                        |             |        configuration          |             |                                  |
@@ -35,3 +72,4 @@ To ilustrate whole concept of chanied settings:
     |                        | included by |                               | included by |                                  |
     |   geonode.settings     |     ->      |  geonode_generic.settings    |      ->     |  geonode_generic.local_settings |
     +------------------------|-------------|-------------------------------|-------------|----------------------------------+
+```

--- a/templates/geonode-generic/1/docker-compose.yml
+++ b/templates/geonode-generic/1/docker-compose.yml
@@ -40,7 +40,9 @@ services:
        GEONODE_INSTANCE_NAME: geonode
        GEONODE_LB_HOST_IP:
        GEONODE_LB_PORT:
-       DATABASE_URL: postgres://postgres:postgres@db:5432/postgres
+       # Database URL should be in the form:
+       # postgresql://[user[:password]@][netloc][:port][/dbname][?param1=value1&...]
+       DATABASE_URL: postgres://postgres:postgres@db:5432/geonode
        DEFAULT_BACKEND_DATASTORE: datastore
        GEONODE_DATABASE: geonode
        GEONODE_DATABASE_PASSWORD: geonode


### PR DESCRIPTION
I tested on my fork of your catalogue and with my patch applied the data is now written to the correct database for geonode.

```
root@e35908a7597f:/# su - postgres
No directory, logging in with HOME=/
$ psql geonode
psql (9.6.8)
Type "help" for help.

geonode=# \d
                                    List of relations
 Schema |                           Name                           |   Type   |  Owner
--------+----------------------------------------------------------+----------+----------
 public | account_emailaddress                                     | table    | postgres
 public | account_emailaddress_id_seq                              | sequence | postgres
 public | account_emailconfirmation                                | table    | postgres
 public | account_emailconfirmation_id_seq                         | sequence | postgres
 public | actstream_action                                         | table    | postgres
 public | actstream_action_id_seq                                  | sequence | postgres
 public | actstream_follow                                         | table    | postgres
 public | actstream_follow_id_seq                                  | sequence | postgres
 public | agon_ratings_overallrating                               | table    | postgres
 public | agon_ratings_overallrating_id_seq                        | sequence | postgres
 public | agon_ratings_rating                                      | table    | postgres
 public | agon_ratings_rating_id_seq                               | sequence | postgres
 public | announcements_announcement                               | table    | postgres
 public | announcements_announcement_id_seq                        | sequence | postgres
 public | announcements_dismissal                                  | table    | postgres
 public | announcements_dismissal_id_seq                           | sequence | postgres
 public | auth_group                                               | table    | postgres
 public | auth_group_id_seq                                        | sequence | postgres
 public | auth_group_permissions                                   | table    | postgres
 public | auth_group_permissions_id_seq                            | sequence | postgres
 public | auth_permission                                          | table    | postgres
 public | auth_permission_id_seq                                   | sequence | postgres
 public | avatar_avatar                                            | table    | postgres
 public | avatar_avatar_id_seq                                     | sequence | postgres
 public | base_backup                                              | table    | postgres
 public | base_backup_id_seq                                       | sequence | postgres
 public | base_contactrole                                         | table    | postgres
 public | base_contactrole_id_seq                                  | sequence | postgres
 public | base_hierarchicalkeyword                                 | table    | postgres
 public | base_hierarchicalkeyword_id_seq                          | sequence | postgres
 public | base_license                                             | table    | postgres
 public | base_license_id_seq                                      | sequence | postgres
 public | base_link                                                | table    | postgres
 public | base_link_id_seq                                         | sequence | postgres
 public | base_region                                              | table    | postgres
 public | base_region_id_seq                                       | sequence | postgres
--More--
```

I havent tested to see where geoserver data is written yet...